### PR TITLE
Pin Sphinx to 8.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx
+Sphinx==8.2.3
 sphinx_rtd_theme
 sphinx_rtd_theme_ext_color_contrast
 myst_nb


### PR DESCRIPTION
There are various problems with sphinx-tabs (from sphinx-lesson) with Sphinx 9. See https://github.com/executablebooks/sphinx-tabs/issues/209 and https://github.com/executablebooks/sphinx-tabs/issues/212 . Let's pin to the newest version from the 8.x series.